### PR TITLE
README.md: point to DEVELOPING.md for first time setup instructions

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -46,6 +46,8 @@ env TOPDIR=dkmldir/vendor/drc/all/emptytop \
 make local-install
 ```
 
+(this also works on Linux)
+
 It is okay if it fails. You can do more local troubleshooting with:
 
 ```sh
@@ -70,3 +72,5 @@ env TOPDIR=dkmldir/vendor/drc/all/emptytop \
     share/dkml/repro/100co/vendor/dkml-compiler/src/r-c-ocaml-3-build_cross-noargs.sh 2>&1 | \
     tee build_cross.log)
 ```
+
+You can also add `--verbose` to the 'opam install' line in the Makefile.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ rm -rf dl ; git restore dl/.gitkeep
 opam install ./dkml-base-compiler.opam --inplace-build --update-invariant
 ```
 
+It is recommended to first follow the instructions in DEVELOPING.md
+to set up (an empty) opam switch with the appropriate external repositories.
+
 ### Patching
 
 In what follows, `VER` is a placeholder for the OCaml major version (ex. `4`)


### PR DESCRIPTION
The 'opam install' line in the README.md didn't work on Linux:
```
opam install ./dkml-base-compiler.opam --inplace-build --update-invariant
[NOTE] Package dkml-base-compiler is currently pinned to git+file:///var/home/edwin/git/dkml-compiler#main (version 4.14.0~v1.1.0).
dkml-base-compiler is now pinned to git+file:///var/home/edwin/nocow/dkml-compiler#docs (version 4.14.0~v1.1.0)
[ERROR] Package conflict!
  * Incompatible packages:
    - dkml-base-compiler >= 4.14.0~v1.1.0
    - dkml-base-compiler >= 4.14.0~v1.1.0 → ocaml = 4.14.0 → ocaml-base-compiler < 4.14.1~
  * Missing dependency:
    - dkml-base-compiler >= 4.14.0~v1.1.0 → ocaml = 4.14.0 → ocaml-variants < 4.14.1~ → ocaml-beta
    unmet availability conditions: 'enable-ocaml-beta-repository'
```

However the `make local-install` line from DEVELOPING.md did work.

Emphasize that the MacOS instructions work on Linux too (at least the first one does, the 2nd one would have OS specific vars).

Also add a hint about using `--verbose` to debug opam installation.