### PR TITLE
ocaml_make: always use -j$NUMCPUS

### DIFF
--- a/src/r-c-ocaml-functions.sh
+++ b/src/r-c-ocaml-functions.sh
@@ -101,7 +101,7 @@ detect_msvs() {
   fi
 }
 
-ocaml_make() {
+ocaml_make_real() {
   ocaml_make_ABI=$1
   shift
 
@@ -142,6 +142,12 @@ ocaml_make() {
         exit 107
     fi
   fi
+}
+
+ocaml_make() {
+    ocaml_make_real \
+        "$@" \
+        -j"$NUMCPUS" -l"$NUMCPUS"
 }
 
 ocaml_configure_windows() {
@@ -531,7 +537,6 @@ make_caml() {
   shift
 
   ocaml_make "$make_caml_ABI" \
-    -j"$NUMCPUS" -l"$NUMCPUS" \
     CAMLDEP="$CAMLDEP" \
     CAMLLEX="$OCAMLLEX" OCAMLLEX="$OCAMLLEX" \
     CAMLYACC="$OCAMLYACC" OCAMLYACC="$OCAMLYACC" \


### PR DESCRIPTION
There are several invocations of `ocaml_make`, some through `make_caml`, but not all.
The ones through `make_caml` already added `-j`, but the others (e.g. building the runtime itself) didn't.

Use -j and -l consistently, from my local testing this works, and it is the way the OCaml compiler is built in opam since OCaml 4.07.0. (Some older versions of the compile did have issues with parallel builds)

The first argument to `ocaml_make` has special meaning, so append these flags.

A measurement on the following system shows a speedup:
```
CPU: 12-core AMD Ryzen 9 3900X (-MT MCP-) speed/min/max: 3799/2200/4672 MHz
Kernel: 6.0.15-300.fc37.x86_64 x86_64 Up: 3h 33m Mem: 4850.1/64214.0 MiB
(7.6%) Storage: 24.99 TiB (3.1% used) Procs: 457 Shell: Zsh inxi: 3.3.24
```

```
hyperfine --min-runs 3 -n mine --prepare 'git clean -xfd; rm -rf _opam; git checkout main' 'make local-install' -n unmodified-upstream --prepare 'git clean -xfd; rm -rf _opam; git checkout origin/main' 'make local-install'
Benchmark 1: mine
  Time (mean ± σ):     119.079 s ±  0.175 s    [User: 343.173 s, System: 47.404 s]
  Range (min … max):   118.915 s … 119.264 s    3 runs

Benchmark 2: unmodified-upstream
  Time (mean ± σ):     307.455 s ±  0.148 s    [User: 340.499 s, System: 46.774 s]
  Range (min … max):   307.285 s … 307.557 s    3 runs

Summary
  'mine' ran
    2.58 ± 0.00 times faster than 'unmodified-upstream'
```

(note that NUMCPUS is limited to max 8 in `dkml-runtime-common` currently)

(Not mentioned in the commit message, but I used the following script to make measurement results less noisy:
```
#!/bin/sh
set -eu
cpupower frequency-set -g performance
cpupower idle-set -D 1
echo 0 >/sys/devices/system/cpu/cpufreq/boost
```

There are other tweaks that could be done but the above is sufficient to gain sufficient accuracy.
The build was run on an NVME drive, to further increase measurement accuracy it could be done from a `tmpfs`, but the results are accurate enough as they are with <0.2% deviation)